### PR TITLE
feat: support gemma model launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,27 @@ p.s.
 ### 2.3 Launching the LLM Models
 #### 2.3.1 [Optional] Running the LLM Models
 ```bash
+bash llm_service/launch_llm.sh <port> <gpu_id> [model_path]
+```
+to launch a single LLM model server. The optional `model_path` argument
+specifies the Hugging Face identifier or local path of the model to
+load.
+
+For example, to run the open source Gemma 3 model with 270M parameters on
+Google Colab:
+
+```bash
+!pip install -r requirements.txt vllm
+!bash llm_service/launch_llm.sh 8083 0 google/gemma-3-270m
+```
+
+To launch several models concurrently, you can still use:
+
+```bash
 bash llm_service/launch_all_llm.sh
 ```
-to launch the LLM model server.
 
-p.s. 
+p.s.
 - You can set multiply LLM models.
 - You can also use other LLM APIs based on vllm inference framework.
 

--- a/llm_service/launch_llm.sh
+++ b/llm_service/launch_llm.sh
@@ -1,22 +1,23 @@
 #!/bin/bash
 
 if [ -z "$1" ] || [ -z "$2" ]; then
-    echo "usage: $0 <port> <gpu_id>"
+    echo "usage: $0 <port> <gpu_id> [model_path]"
     exit 1
 fi
 
 port=$1
 gpuid=$2
+LLM_FILE=${3:-"google/gemma-3-270m"}
+
 export CUDA_VISIBLE_DEVICES="$gpuid"
 export VLLM_ATTENTION_BACKEND=XFORMERS
 
 echo "Port: $port"
 echo "GPU ID: $CUDA_VISIBLE_DEVICES"
+echo "Model: $LLM_FILE"
 
 current_dir=$(cd `dirname $0`; pwd)
 llm_tuning_dir="$(dirname "$current_dir")/llm_tuning/saves"
-
-LLM_FILE="your_llm_path"
 
 LOG_FILE="${current_dir}/.log"
 PID_FILE="${current_dir}/.pid"


### PR DESCRIPTION
## Summary
- allow specifying model path when launching LLM
- document launching Gemma 3 270M on Google Colab

## Testing
- `bash -n llm_service/launch_llm.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1c71889c4832e8938df61e7d5e4ed